### PR TITLE
Adds NoSleepJs library to prevent iOS and Android devices from sleeping upon user intervention

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,7 @@
+Unreleased
+
+* Prevent screen from sleeping (@zakir8)
+
 1.1.2
 
 * Add webrick as a runtime dependency

--- a/public/index.html
+++ b/public/index.html
@@ -2,6 +2,7 @@
 <html>
   <head>
     <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1">
     <title>weblink</title>
     <link rel="manifest" href="/weblink.webmanifest">
     <style>
@@ -15,34 +16,18 @@
         color: white;
         display: flex;
         justify-content: center;
+        flex-direction: column;
       }
-      .container {
-        position: relative;
-      }
-      .main {
-        text-align: center;
-        font-size: 8em;
-      }
-      button {
-        color: black;
-        border:0.1em solid #000000;
-        border-color: #FFFFFF;
-        background-color: #FFFFFF;
-        padding: 15px 15px;
-        text-align: center;
-        text-decoration: none;
-        font-size: 40px;
-        margin:0 auto;
-        display:block;
-        transition: all 0.1s ease-in-out;
-        border-radius: 10rem;
+      h1 {
+        font-size: 3rem;
       }
     </style>
   </head>
   <body>
-    <div class="container">
-      <h1 class="main">weblink</h1>
-      <button id="nowake">Click to prevent screen from sleeping</button>
+    <h1>weblink</h1>
+    <div class="settings">
+      <input type="checkbox" id="nosleep" />
+      <label for="nosleep">Prevent screen from sleeping</label>
     </div>
 
     <script>
@@ -92,7 +77,10 @@
       };
     </script>
   </body>
-
-  <script src="https://cdnjs.cloudflare.com/ajax/libs/nosleep/0.12.0/NoSleep.min.js" type="text/javascript" crossorigin="anonymous"></script>
-  <script src="./index.js" type="text/javascript"></script>
+  <script
+    src="https://cdnjs.cloudflare.com/ajax/libs/nosleep/0.12.0/NoSleep.min.js"
+    type="text/javascript"
+    crossorigin="anonymous"
+  ></script>
+  <script src="index.js" type="text/javascript"></script>
 </html>

--- a/public/index.html
+++ b/public/index.html
@@ -7,22 +7,44 @@
     <style>
       html, body {
         height: 100%;
+        background-color: #3f9cff;
+        font-family: sans-serif;
       }
       body {
         align-items: center;
-        background-color: #3f9cff;
         color: white;
         display: flex;
         justify-content: center;
       }
-      h1 {
-        font-family: sans-serif;
+      .container {
+        position: relative;
+      }
+      .main {
+        text-align: center;
         font-size: 8em;
+      }
+      button {
+        color: black;
+        border:0.1em solid #000000;
+        border-color: #FFFFFF;
+        background-color: #FFFFFF;
+        padding: 15px 15px;
+        text-align: center;
+        text-decoration: none;
+        font-size: 40px;
+        margin:0 auto;
+        display:block;
+        transition: all 0.1s ease-in-out;
+        border-radius: 10rem;
       }
     </style>
   </head>
   <body>
-    <h1>weblink</h1>
+    <div class="container">
+      <h1 class="main">weblink</h1>
+      <button id="nowake">Click to prevent screen from sleeping</button>
+    </div>
+
     <script>
       function connect(client_addr, server_addr, proxy) {
         var client, server = new WebSocket(server_addr + "/proxy/" + proxy);
@@ -70,4 +92,7 @@
       };
     </script>
   </body>
+
+  <script src="https://cdnjs.cloudflare.com/ajax/libs/nosleep/0.12.0/NoSleep.min.js" type="text/javascript" crossorigin="anonymous"></script>
+  <script src="./index.js" type="text/javascript"></script>
 </html>

--- a/public/index.js
+++ b/public/index.js
@@ -1,0 +1,19 @@
+var noSleep = new NoSleep();
+var noWakeEnabled = false;
+var noWakeElement = document.querySelector("#nowake");
+
+noWakeElement.addEventListener('click', function() {
+  if (!noWakeEnabled) {
+    noSleep.enable();
+    noWakeEnabled = true;
+    noWakeElement.textContent = "Screen Awake! Click to disable";
+    noWakeElement.style.backgroundColor = "#3f9cff";
+    noWakeElement.style.color = "#FFFFFF"
+  } else {
+    noSleep.disable();
+    noWakeEnabled = false;
+    noWakeElement.textContent = "Click to prevent screen from sleeping";
+    noWakeElement.style.backgroundColor = "white";
+    noWakeElement.style.color = "#000000"
+  }
+}, false);

--- a/public/index.js
+++ b/public/index.js
@@ -1,19 +1,22 @@
 var noSleep = new NoSleep();
-var noWakeEnabled = false;
-var noWakeElement = document.querySelector("#nowake");
+var noSleepCheckbox = document.getElementById("nosleep");
 
-noWakeElement.addEventListener('click', function() {
-  if (!noWakeEnabled) {
-    noSleep.enable();
-    noWakeEnabled = true;
-    noWakeElement.textContent = "Screen Awake! Click to disable";
-    noWakeElement.style.backgroundColor = "#3f9cff";
-    noWakeElement.style.color = "#FFFFFF"
-  } else {
+document.addEventListener("visibilitychange", function resetNoSleep(event) {
+  if (document.visibilityState === "visible") {
     noSleep.disable();
-    noWakeEnabled = false;
-    noWakeElement.textContent = "Click to prevent screen from sleeping";
-    noWakeElement.style.backgroundColor = "white";
-    noWakeElement.style.color = "#000000"
+    noSleep = new NoSleep();
+    noSleepCheckbox.checked = false;
   }
-}, false);
+});
+
+noSleepCheckbox.addEventListener("click", function toggleNoSleep(event) {
+  if (noSleep.isEnabled) {
+    noSleep.disable();
+  } else {
+    try {
+      noSleep.enable();
+    } catch (error) {
+      event.preventDefault();
+    }
+  }
+});


### PR DESCRIPTION
**Problem:** Most phones are set to a minute timeout and iOS web server seems to be disconnected if phone screen gets timeout. It's not a pleasant scenario if the phone is not on charge all the time while using this. 

**Solution:** A way to keep browsers active is by playing a audio/video in a loop in the background. This allows the weblink server to always be active to passthrough the traffic. I utilized a library called [NoSleep.js](https://github.com/richtr/NoSleep.js/) to keep the session active and included a button on the webpage for the user to make it active. I am using a CDN minified version of the library for better access. This file once loaded in a browser seems to be cached. 

<img width="294" alt="image" src="https://user-images.githubusercontent.com/7065146/172069116-9637dbef-c15a-4bc1-b181-385ab4cd8af0.png">


Please let me know if you have any questions or concerns. 