### PR TITLE
update render.yaml

### DIFF
--- a/render.yaml
+++ b/render.yaml
@@ -5,5 +5,5 @@ services:
     plan: free
     buildCommand: bundle install
     startCommand: netpump --server --server-port $PORT
-    branch: main
+    branch: master
     healthCheckPath: /healthcheck


### PR DESCRIPTION
the base branch is called `master` and not `main`
with this change alone, I successfully deployed an instance to Render with no additional configuration